### PR TITLE
Optional skip param for FileNet_SendFile

### DIFF
--- a/gamedata/filenetwork.txt
+++ b/gamedata/filenetwork.txt
@@ -4,7 +4,7 @@
 	{
 		"Keys"
 		{
-			"EngineInterface"	"VEngineServer021"
+			"EngineInterface"	"VEngineServer023"
 		}
 		"Signatures"
 		{
@@ -13,6 +13,108 @@
 				"library"	"engine"
 				"windows"	"@CreateInterface"
 				"linux"		"@CreateInterface"
+			}
+		}
+        "Offsets"
+        {
+            "GetPlayerNetInfo"
+            {
+                "windows"    "20"
+                "linux"      "20"
+            }
+        }
+	}
+
+	"csgo"
+	{
+		"Keys"
+		{
+			"EngineInterface"	"VEngineServer023"
+		}
+		"Signatures"
+		{
+			"CreateInterface"
+			{
+				"library"	"engine"
+				"windows"	"@CreateInterface"
+				"linux"		"@CreateInterface"
+			}
+			"CNetChan::SendFile"
+			{
+				"library"	"engine"
+				"windows"	"\x55\x8B\xEC\x57\x8B\xF9\x8B\x07\x8B\x80\x00\x01\x00\x00\xFF\xD0"
+				// "SendFile: %s (ID %i)\n"
+			}
+			"CNetChan::RequestFile"
+			{
+				"library"	"engine"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x3C\x56\x8B\xF1\xFF\x86\x90\x04\x00\x00\x8B\x0D"
+				// "RequestFile: %s (ID %i)\n"
+			}
+			"CNetChan::IsFileInWaitingList"
+			{
+				"library"	"engine"
+				"windows"	"\x55\x8B\xEC\x51\x56\x8B\x75\x08\x8B\xC1\x56"
+				// "CreateFragmentsFromFile: '%s' doesn't e" -> CNetChan::CreateFragmentsFromFile
+				// Top Call -> CNetChan::IsFileInWaitingList
+			}
+			"CGameClient::FileReceived"
+			{
+				"library"	"engine"
+
+				"windows"	"\x55\x8B\xEC\x56\x8B\x75\x0C\x33\xD2\x57\x8B\xF9"
+				// "CGameClient::FileReceived: %s not wanted.\n"
+			}
+			"CGameClient::FileDenied"
+			{
+				"library"	"engine"
+				"windows"	"\x55\x8B\xEC\x8B\x01\xFF\x50\x4C\x50\x2A\x2A\x2A\x2A\x80"
+				// "Downloading file '%s' from client %s failed.\n"
+			}
+			"CBaseClient::GetNetChannel"
+			{
+				"library"	"engine"
+				"windows"	"\x8B\x81\xC0\x00\x00\x00"
+				// Good Luck
+			}
+		}
+		"Functions"
+		{
+			"CGameClient::FileReceived"
+			{
+				"signature"	"CGameClient::FileReceived"
+				"callconv"	"thiscall"
+				"return"	"void"
+				"this"		"address"
+				"arguments"
+				{
+					"fileName"
+					{
+						"type"	"charptr"
+					}
+					"transferID "
+					{
+						"type"	"int"
+					}
+				}
+			}
+			"CGameClient::FileDenied"
+			{
+				"signature"	"CGameClient::FileDenied"
+				"callconv"	"thiscall"
+				"return"	"void"
+				"this"		"address"
+				"arguments"
+				{
+					"fileName"
+					{
+						"type"	"charptr"
+					}
+					"transferID "
+					{
+						"type"	"int"
+					}
+				}
 			}
 		}
         "Offsets"
@@ -57,7 +159,7 @@
 			"CGameClient::FileReceived"
 			{
 				"library"	"engine"
-				"linux"		"@_ZN11CGameClient12FileReceivedEPKcj"
+				"linux"		"@_ZZN11CGameClient12FileReceivedEPKcj"
 				"windows"	"\x55\x8B\xEC\x56\x8B\x75\x0C\x33\xD2\x57\x8B\xF9"
 				// "CGameClient::FileReceived: %s not wanted.\n"
 			}

--- a/gamedata/filenetwork.txt
+++ b/gamedata/filenetwork.txt
@@ -1,20 +1,22 @@
 "Games"
 {
-	"#default"
-	{
-		"Keys"
-		{
-			"EngineInterface"	"VEngineServer023"
-		}
-		"Signatures"
-		{
-			"CreateInterface"
-			{
-				"library"	"engine"
-				"windows"	"@CreateInterface"
-				"linux"		"@CreateInterface"
-			}
-		}
+    "#default"
+    {
+        "Keys"
+        {
+            "EngineInterface"	"VEngineServer021"
+        }
+
+        "Signatures"
+        {
+            "CreateInterface"
+            {
+                "library"	"engine"
+                "windows"	"@CreateInterface"
+                "linux"		"@CreateInterface"
+            }
+        }
+
         "Offsets"
         {
             "GetPlayerNetInfo"
@@ -23,199 +25,241 @@
                 "linux"      "20"
             }
         }
-	}
+    }
 
-	"csgo"
-	{
-		"Keys"
-		{
-			"EngineInterface"	"VEngineServer023"
-		}
-		"Signatures"
-		{
-			"CreateInterface"
-			{
-				"library"	"engine"
-				"windows"	"@CreateInterface"
-				"linux"		"@CreateInterface"
-			}
-			"CNetChan::SendFile"
-			{
-				"library"	"engine"
-				"windows"	"\x55\x8B\xEC\x57\x8B\xF9\x8B\x07\x8B\x80\x00\x01\x00\x00\xFF\xD0"
-				// "SendFile: %s (ID %i)\n"
-			}
-			"CNetChan::RequestFile"
-			{
-				"library"	"engine"
-				"windows"	"\x55\x8B\xEC\x83\xEC\x3C\x56\x8B\xF1\xFF\x86\x90\x04\x00\x00\x8B\x0D"
-				// "RequestFile: %s (ID %i)\n"
-			}
-			"CNetChan::IsFileInWaitingList"
-			{
-				"library"	"engine"
-				"windows"	"\x55\x8B\xEC\x51\x56\x8B\x75\x08\x8B\xC1\x56"
-				// "CreateFragmentsFromFile: '%s' doesn't e" -> CNetChan::CreateFragmentsFromFile
-				// Top Call -> CNetChan::IsFileInWaitingList
-			}
-			"CGameClient::FileReceived"
-			{
-				"library"	"engine"
+    "tf"
+    {
+        "Keys"
+        {
+            "EngineInterface"	"VEngineServer023"
+        }
 
-				"windows"	"\x55\x8B\xEC\x56\x8B\x75\x0C\x33\xD2\x57\x8B\xF9"
-				// "CGameClient::FileReceived: %s not wanted.\n"
-			}
-			"CGameClient::FileDenied"
-			{
-				"library"	"engine"
-				"windows"	"\x55\x8B\xEC\x8B\x01\xFF\x50\x4C\x50\x2A\x2A\x2A\x2A\x80"
-				// "Downloading file '%s' from client %s failed.\n"
-			}
-			"CBaseClient::GetNetChannel"
-			{
-				"library"	"engine"
-				"windows"	"\x8B\x81\xC0\x00\x00\x00"
-				// Good Luck
-			}
-		}
-		"Functions"
-		{
-			"CGameClient::FileReceived"
-			{
-				"signature"	"CGameClient::FileReceived"
-				"callconv"	"thiscall"
-				"return"	"void"
-				"this"		"address"
-				"arguments"
-				{
-					"fileName"
-					{
-						"type"	"charptr"
-					}
-					"transferID "
-					{
-						"type"	"int"
-					}
-				}
-			}
-			"CGameClient::FileDenied"
-			{
-				"signature"	"CGameClient::FileDenied"
-				"callconv"	"thiscall"
-				"return"	"void"
-				"this"		"address"
-				"arguments"
-				{
-					"fileName"
-					{
-						"type"	"charptr"
-					}
-					"transferID "
-					{
-						"type"	"int"
-					}
-				}
-			}
-		}
+        "Signatures"
+        {
+            "CNetChan::SendFile"
+            {
+                "library"	"engine"
+                "linux"		"@_ZN8CNetChan8SendFileEPKcj"
+                "windows"	"\x55\x8B\xEC\x57\x8B\xF9\x8D\x8F\x94\x00\x00\x00\xE8\x2A\x2A\x2A\x2A\x85\xC0\x75\x2A\xB0\x01\x5F\x5D\xC2\x08\x00\x56\x8B\x75\x08\x85\xF6"
+                // "SendFile: %s (ID %i)\n"
+            }
+
+            "CNetChan::RequestFile"
+            {
+                "library"	"engine"
+                "linux"		"@_ZN8CNetChan11RequestFileEPKc"
+                "windows"	"\x55\x8B\xEC\x83\xEC\x14\x53\x8B\xD9\x56\x89\x5D\xF4"
+                // "RequestFile: %s (ID %i)\n"
+            }
+
+            "CNetChan::IsFileInWaitingList"
+            {
+                "library"	"engine"
+                "linux"		"@_ZN8CNetChan19IsFileInWaitingListEPKc"
+                "windows"	"\x55\x8B\xEC\x8B\x45\x08\x83\xEC\x08\x85\xC0\x0F\x84\x2A\x2A\x2A\x2A\x80\x38\x00"
+                // "CreateFragmentsFromFile: '%s' doesn't e" -> CNetChan::CreateFragmentsFromFile
+                // Top Call -> CNetChan::IsFileInWaitingList
+            }
+
+            "CGameClient::FileReceived"
+            {
+                "library"	"engine"
+                "linux"		"@_ZZN11CGameClient12FileReceivedEPKcj"
+                "windows"	"\x55\x8B\xEC\x56\x8B\x75\x0C\x33\xD2\x57\x8B\xF9"
+                // "CGameClient::FileReceived: %s not wanted.\n"
+            }
+
+            "CGameClient::FileDenied"
+            {
+                "library"	"engine"
+                "linux"		"@_ZN11CGameClient10FileDeniedEPKcj"
+                "windows"	"\x55\x8B\xEC\x8B\x01\xFF\x50\x44\x50\xFF\x75\x08\x68"
+                // "Downloading file '%s' from client %s failed.\n"
+            }
+
+            "CBaseClient::GetNetChannel"
+            {
+                "library"	"engine"
+                "linux"		"@_ZN11CBaseClient13GetNetChannelEv"
+                "windows"	"\x8B\x81\xC0\x00\x00\x00"
+                // Good Luck
+            }
+        }
+
+        "Functions"
+        {
+            "CGameClient::FileReceived"
+            {
+                "signature"	"CGameClient::FileReceived"
+                "callconv"	"thiscall"
+                "return"	"void"
+                "this"		"address"
+
+                "arguments"
+                {
+                    "fileName"
+                    {
+                        "type"	"charptr"
+                    }
+
+                    "transferID"
+                    {
+                        "type"	"int"
+                    }
+                }
+            }
+
+            "CGameClient::FileDenied"
+            {
+                "signature"	"CGameClient::FileDenied"
+                "callconv"	"thiscall"
+                "return"	"void"
+                "this"		"address"
+
+                "arguments"
+                {
+                    "fileName"
+                    {
+                        "type"	"charptr"
+                    }
+
+                    "transferID"
+                    {
+                        "type"	"int"
+                    }
+                }
+            }
+        }
+    }
+
+    "csgo"
+    {
+        "Keys"
+        {
+            "EngineInterface"	"VEngineServer023"
+        }
+
+        "Addresses"
+        {
+            "CBaseClient::m_NetChannelOffset"
+            {
+                "signature"	"CBaseClient::EndTrace"
+
+                "linux"
+                {
+                    "offset"	"66"
+                }
+                "windows"
+                {
+                    "offset"	"68"
+                }
+            }
+        }
+
         "Offsets"
         {
             "GetPlayerNetInfo"
             {
-                "windows"    "20"
-                "linux"      "20"
+                "windows"    "22"
+                "linux"      "22"
             }
         }
-	}
-	"tf"
-	{
-		"Keys"
-		{
-			"EngineInterface"	"VEngineServer023"
-		}
-		"Signatures"
-		{
-			"CNetChan::SendFile"
-			{
-				"library"	"engine"
-				"linux"		"@_ZN8CNetChan8SendFileEPKcj"
-				"windows"	"\x55\x8B\xEC\x57\x8B\xF9\x8D\x8F\x94\x00\x00\x00\xE8\x2A\x2A\x2A\x2A\x85\xC0\x75\x2A\xB0\x01\x5F\x5D\xC2\x08\x00\x56\x8B\x75\x08\x85\xF6"
-				// "SendFile: %s (ID %i)\n"
-			}
-			"CNetChan::RequestFile"
-			{
-				"library"	"engine"
-				"linux"		"@_ZN8CNetChan11RequestFileEPKc"
-				"windows"	"\x55\x8B\xEC\x83\xEC\x14\x53\x8B\xD9\x56\x89\x5D\xF4"
-				// "RequestFile: %s (ID %i)\n"
-			}
-			"CNetChan::IsFileInWaitingList"
-			{
-				"library"	"engine"
-				"linux"		"@_ZN8CNetChan19IsFileInWaitingListEPKc"
-				"windows"	"\x55\x8B\xEC\x8B\x45\x08\x83\xEC\x08\x85\xC0\x0F\x84\x2A\x2A\x2A\x2A\x80\x38\x00"
-				// "CreateFragmentsFromFile: '%s' doesn't e" -> CNetChan::CreateFragmentsFromFile
-				// Top Call -> CNetChan::IsFileInWaitingList
-			}
-			"CGameClient::FileReceived"
-			{
-				"library"	"engine"
-				"linux"		"@_ZZN11CGameClient12FileReceivedEPKcj"
-				"windows"	"\x55\x8B\xEC\x56\x8B\x75\x0C\x33\xD2\x57\x8B\xF9"
-				// "CGameClient::FileReceived: %s not wanted.\n"
-			}
-			"CGameClient::FileDenied"
-			{
-				"library"	"engine"
-				"linux"		"@_ZN11CGameClient10FileDeniedEPKcj"
-				"windows"	"\x55\x8B\xEC\x8B\x01\xFF\x50\x44\x50\xFF\x75\x08\x68"
-				// "Downloading file '%s' from client %s failed.\n"
-			}
-			"CBaseClient::GetNetChannel"
-			{
-				"library"	"engine"
-				"linux"		"@_ZN11CBaseClient13GetNetChannelEv"
-				"windows"	"\x8B\x81\xC0\x00\x00\x00"
-				// Good Luck
-			}
-		}
-		"Functions"
-		{
-			"CGameClient::FileReceived"
-			{
-				"signature"	"CGameClient::FileReceived"
-				"callconv"	"thiscall"
-				"return"	"void"
-				"this"		"address"
-				"arguments"
-				{
-					"fileName"
-					{
-						"type"	"charptr"
-					}
-					"transferID "
-					{
-						"type"	"int"
-					}
-				}
-			}
-			"CGameClient::FileDenied"
-			{
-				"signature"	"CGameClient::FileDenied"
-				"callconv"	"thiscall"
-				"return"	"void"
-				"this"		"address"
-				"arguments"
-				{
-					"fileName"
-					{
-						"type"	"charptr"
-					}
-					"transferID "
-					{
-						"type"	"int"
-					}
-				}
-			}
-		}
-	}
+
+        "Signatures"
+        {
+            "CBaseClient::EndTrace"
+            {
+                "library"	"engine"
+                "linux"		"\x55\x89\xE5\x57\x56\x53\x83\xEC\x5C\x8B\x7D\x08\x8B\x87\xB0\x03\x00\x00"
+                "windows"	"\x55\x8B\xEC\x83\xEC\x38\x53\x8B\xD9\x56"
+                // "%f/%d Player [%s][%d][adr:%s] was sent a datagram %d bits (%8.3f bytes)\n"
+            }
+
+            "CNetChan::SendFile"
+            {
+                "library"	"engine"
+                "linux"		"\x55\x89\xE5\x57\x56\x53\x83\xEC\x1C\x8B\x75\x08\x8B\x5D\x0C\x8B\x7D\x14"
+                "windows"	"\x55\x8B\xEC\x57\x8B\xF9\x8B\x07\x8B\x80\x00\x01\x00\x00"
+                // "SendFile: %s (ID %i)\n"
+            }
+
+            "CNetChan::RequestFile"
+            {
+                "library"	"engine"
+                "linux"		"\x55\x89\xE5\x57\x56\x53\x83\xEC\x4C\x8B\x45\x10\x8B\x5D\x08"
+                "windows"	"\x55\x8B\xEC\x83\xEC\x3C\x56\x8B\xF1\xFF\x86\x90\x04\x00\x00"
+                // "RequestFile: %s (ID %i)\n"
+            }
+
+            "CNetChan::IsFileInWaitingList"
+            {
+                "library"	"engine"
+                "linux"		"\x55\x89\xE5\x57\x56\x8D\xB0\x30\x01\x00\x00"
+                "windows"	"\x55\x8B\xEC\x8B\x45\x08\x83\xEC\x08\x85\xC0\x0F\x84\x2A\x2A\x2A\x2A"
+                // "CreateFragmentsFromFile: '%s' doesn't e" -> CNetChan::CreateFragmentsFromFile
+                // Top Call -> CNetChan::IsFileInWaitingList
+            }
+
+            "CGameClient::FileReceived"
+            {
+                "library"	"engine"
+                "linux"		"\x55\x31\xC0\x89\xE5\x53\x8B\x55\x08\x8B\x5D\x0C\x8B\x4D\x10\x39\x8C\xC2\xEC\x01\x00\x00"
+                "windows"	"\x55\x8B\xEC\x56\x8B\x75\x0C\x33\xD2\x57"
+                // "CGameClient::FileReceived: %s not wanted.\n"
+            }
+
+            "CGameClient::FileDenied"
+            {
+                "library"	"engine"
+                "linux"		"\x55\x89\xE5\x53\x83\xEC\x04\x8B\x45\x08\x8B\x5D\x0C\x8B\x10"
+                "windows"	"\x55\x8B\xEC\x8B\x01\xFF\x50\x4C\x50\xFF\x75\x08\x68"
+                // "Downloading file '%s' from client %s failed.\n"
+            }
+        }
+
+        "Functions"
+        {
+            "CGameClient::FileReceived"
+            {
+                "signature"	"CGameClient::FileReceived"
+                "callconv"	"thiscall"
+                "return"	"void"
+                "this"		"address"
+
+                "arguments"
+                {
+                    "fileName"
+                    {
+                        "type"	"charptr"
+                    }
+
+                    "transferID"
+                    {
+                        "type"	"int"
+                    }
+                }
+            }
+
+            "CGameClient::FileDenied"
+            {
+                "signature"	"CGameClient::FileDenied"
+                "callconv"	"thiscall"
+                "return"	"void"
+                "this"		"address"
+
+                "arguments"
+                {
+                    "fileName"
+                    {
+                        "type"	"charptr"
+                    }
+
+                    "transferID"
+                    {
+                        "type"	"int"
+                    }
+                }
+            }
+        }
+    }
 }

--- a/scripting/filenetwork.sp
+++ b/scripting/filenetwork.sp
@@ -9,12 +9,13 @@
 
 enum struct FileEnum
 {
-	int Client;
-	char Filename[PLATFORM_MAX_PATH];
-	Handle Plugin;
-	Function Func;
-	any Data;
-	int Id;
+    int Client;
+    char Filename[PLATFORM_MAX_PATH];
+    Handle Plugin;
+    Function Func;
+    any Data;
+
+    int Id;
 }
 
 Handle SDKGetPlayerNetInfo;
@@ -35,460 +36,469 @@ ArrayList RequestListing;
 
 methodmap CNetChan
 {
-	public CNetChan(int client)
-	{
-		return SDKCall(SDKGetPlayerNetInfo, EngineAddress, client);
-	}
+    public CNetChan(int client)
+    {
+        return SDKCall(SDKGetPlayerNetInfo, EngineAddress, client);
+    }
 
-	public bool SendFile(const char[] filename)
-	{
-		return SDKCall(SDKSendFile, this, filename, TransferID++);
-	}
-	public int RequestFile(const char[] filename)
-	{
-		return SDKCall(SDKRequestFile, this, filename);
-	}
-	public bool IsFileInWaitingList(const char[] filename)
-	{
-		return SDKCall(SDKIsFileInWaitingList, this, filename);
-	}
+    public bool SendFile(const char[] filename)
+    {
+        return SDKCall(SDKSendFile, this, filename, TransferID++);
+    }
+    public int RequestFile(const char[] filename)
+    {
+        return SDKCall(SDKRequestFile, this, filename);
+    }
+    public bool IsFileInWaitingList(const char[] filename)
+    {
+        return SDKCall(SDKIsFileInWaitingList, this, filename);
+    }
 }
+
+EngineVersion g_EngineVersion;
 
 public Plugin myinfo =
 {
-	name		=	"File Network",
-	author		=	"Batfoxkid",
-	description	=	"But what if, no loading screen",
-	version		=	PLUGIN_VERSION,
-	url			=	"github.com/Batfoxkid/File-Network"
+    name		=	"File Network",
+    author		=	"Batfoxkid & KoNLiG",
+    description	=	"But what if, no loading screen",
+    version		=	PLUGIN_VERSION,
+    url			=	"github.com/Batfoxkid/File-Network"
 }
 
 public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
 {
-	CreateNative("FileNet_SendFile", Native_SendFile);
-	CreateNative("FileNet_RequestFile", Native_RequestFile);
-	CreateNative("FileNet_IsFileInWaitingList", Native_IsFileInWaitingList);
-	CreateNative("FileNet_GetNetChanPtr", Native_GetNetChanPtr);
+    CreateNative("FileNet_SendFile", Native_SendFile);
+    CreateNative("FileNet_RequestFile", Native_RequestFile);
+    CreateNative("FileNet_IsFileInWaitingList", Native_IsFileInWaitingList);
+    CreateNative("FileNet_GetNetChanPtr", Native_GetNetChanPtr);
 	
-	RegPluginLibrary("filenetwork");
-	return APLRes_Success;
+    RegPluginLibrary("filenetwork");
+    return APLRes_Success;
 }
 
 public void OnPluginStart()
 {
-	GameData gamedata = new GameData("filenetwork");
-	
-	char identifier[64];
-	if(!gamedata.GetKeyValue("EngineInterface", identifier, sizeof(identifier)))
-		SetFailState("[Gamedata] Could not find EngineInterface");
-	
-	StartPrepSDKCall(SDKCall_Static);
-	PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CreateInterface");
-	PrepSDKCall_AddParameter(SDKType_String, SDKPass_Pointer);
-	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Pointer, VDECODE_FLAG_ALLOWNULL);
-	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
-	Handle sdkcall = EndPrepSDKCall();
-	if(!sdkcall)
-		SetFailState("[Gamedata] Could not find CreateInterface");
-	
-	EngineAddress = SDKCall(sdkcall, identifier, 0);
-	if(EngineAddress == Address_Null)
-		SetFailState("[Gamedata] EngineInterface is incorrect for mod");
-	
-	delete sdkcall;
-	
-	bool failed;
+    g_EngineVersion = GetEngineVersion();
 
-	StartPrepSDKCall(SDKCall_Raw);
-	PrepSDKCall_SetFromConf(gamedata, SDKConf_Virtual, "GetPlayerNetInfo");
-	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);
-	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
-	SDKGetPlayerNetInfo = EndPrepSDKCall();
-	if(!SDKGetPlayerNetInfo)
-	{
-		LogError("[Gamedata] Could not find GetPlayerNetInfo");
-		failed = true;
-	}
-	
-	StartPrepSDKCall(SDKCall_Raw);
-	PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CNetChan::SendFile");
-	PrepSDKCall_AddParameter(SDKType_String, SDKPass_Pointer);
-	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);
-	PrepSDKCall_SetReturnInfo(SDKType_Bool, SDKPass_ByValue);
-	SDKSendFile = EndPrepSDKCall();
-	if(!SDKSendFile)
-	{
-		LogError("[Gamedata] Could not find CNetChan::SendFile");
-		failed = true;
-	}
-	
-	StartPrepSDKCall(SDKCall_Raw);
-	PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CNetChan::RequestFile");
-	PrepSDKCall_AddParameter(SDKType_String, SDKPass_Pointer);
-	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_ByValue);
-	SDKRequestFile = EndPrepSDKCall();
-	if(!SDKRequestFile)
-	{
-		LogError("[Gamedata] Could not find CNetChan::RequestFile");
-		failed = true;
-	}
-	
-	StartPrepSDKCall(SDKCall_Raw);
-	PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CNetChan::IsFileInWaitingList");
-	PrepSDKCall_AddParameter(SDKType_String, SDKPass_Pointer);
-	PrepSDKCall_SetReturnInfo(SDKType_Bool, SDKPass_ByValue);
-	SDKIsFileInWaitingList = EndPrepSDKCall();
-	if(!SDKIsFileInWaitingList)
-	{
-		LogError("[Gamedata] Could not find CNetChan::IsFileInWaitingList");
-		failed = true;
-	}
-	
-	StartPrepSDKCall(SDKCall_Raw);
-	PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CBaseClient::GetNetChannel");
-	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_ByValue);
-	SDKGetNetChannel = EndPrepSDKCall();
-	if(!SDKGetNetChannel)
-	{
-		LogError("[Gamedata] Could not find CBaseClient::GetNetChannel");
-		failed = true;
-	}
+    GameData gamedata = new GameData("filenetwork");
 
-	DynamicDetour detour = DynamicDetour.FromConf(gamedata, "CGameClient::FileReceived");
-	if(detour)
-	{
-		if(!detour.Enable(Hook_Post, OnFileReceived))
-		{
-			LogError("[Gamedata] Failed to enable detour: CGameClient::FileReceived");
-			failed = true;
-		}
-		
-		delete detour;
-	}
-	else
-	{
-		LogError("[Gamedata] Could not find CGameClient::FileReceived");
-		failed = true;
-	}
+    char identifier[64];
+    if(!gamedata.GetKeyValue("EngineInterface", identifier, sizeof(identifier)))
+        SetFailState("[Gamedata] Could not find EngineInterface");
 
-	detour = DynamicDetour.FromConf(gamedata, "CGameClient::FileDenied");
-	if(detour)
-	{
-		if(!detour.Enable(Hook_Post, OnFileDenied))
-		{
-			LogError("[Gamedata] Failed to enable detour: CGameClient::FileDenied");
-			failed = true;
-		}
-		
-		delete detour;
-	}
-	else
-	{
-		LogError("[Gamedata] Could not find CGameClient::FileDenied");
-		failed = true;
-	}
+    StartPrepSDKCall(SDKCall_Static);
+    PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CreateInterface");
+    PrepSDKCall_AddParameter(SDKType_String, SDKPass_Pointer);
+    PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Pointer, VDECODE_FLAG_ALLOWNULL);
+    PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
+    Handle sdkcall = EndPrepSDKCall();
+    if(!sdkcall)
+        SetFailState("[Gamedata] Could not find CreateInterface");
 
-	if(failed)
-		ThrowError("Gamedata failed, see error logs");
-	
-	SendListing = new ArrayList(sizeof(FileEnum));
-	RequestListing = new ArrayList(sizeof(FileEnum));
-	RegAdminCmd("sm_filenet_send", Command_TestSend, ADMFLAG_ROOT, "Test using send file");
-	RegAdminCmd("sm_filenet_request", Command_TestRequest, ADMFLAG_ROOT, "Test using request file");
+    EngineAddress = SDKCall(sdkcall, identifier, 0);
+    if(EngineAddress == Address_Null)
+        SetFailState("[Gamedata] EngineInterface is incorrect for mod");
+
+    delete sdkcall;
+
+    bool failed;
+
+    StartPrepSDKCall(SDKCall_Raw);
+    PrepSDKCall_SetFromConf(gamedata, SDKConf_Virtual, "GetPlayerNetInfo");
+    PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);
+    PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
+    SDKGetPlayerNetInfo = EndPrepSDKCall();
+    if(!SDKGetPlayerNetInfo)
+    {
+        LogError("[Gamedata] Could not find GetPlayerNetInfo");
+        failed = true;
+    }
+
+    StartPrepSDKCall(SDKCall_Raw);
+    PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CNetChan::SendFile");
+    PrepSDKCall_AddParameter(SDKType_String, SDKPass_Pointer);
+    PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);
+    PrepSDKCall_SetReturnInfo(SDKType_Bool, SDKPass_ByValue);
+    SDKSendFile = EndPrepSDKCall();
+    if(!SDKSendFile)
+    {
+        LogError("[Gamedata] Could not find CNetChan::SendFile");
+        failed = true;
+    }
+
+    StartPrepSDKCall(SDKCall_Raw);
+    PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CNetChan::RequestFile");
+    PrepSDKCall_AddParameter(SDKType_String, SDKPass_Pointer);
+    PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_ByValue);
+    SDKRequestFile = EndPrepSDKCall();
+    if(!SDKRequestFile)
+    {
+        LogError("[Gamedata] Could not find CNetChan::RequestFile");
+        failed = true;
+    }
+
+    StartPrepSDKCall(SDKCall_Raw);
+    PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CNetChan::IsFileInWaitingList");
+    PrepSDKCall_AddParameter(SDKType_String, SDKPass_Pointer);
+    PrepSDKCall_SetReturnInfo(SDKType_Bool, SDKPass_ByValue);
+    SDKIsFileInWaitingList = EndPrepSDKCall();
+    if(!SDKIsFileInWaitingList)
+    {
+        LogError("[Gamedata] Could not find CNetChan::IsFileInWaitingList");
+        failed = true;
+    }
+
+    if (g_EngineVersion != Engine_CSGO)
+    {
+        StartPrepSDKCall(SDKCall_Raw);
+        PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CBaseClient::GetNetChannel");
+        PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_ByValue);
+        SDKGetNetChannel = EndPrepSDKCall();
+        if(!SDKGetNetChannel)
+        {
+            LogError("[Gamedata] Could not find CBaseClient::GetNetChannel");
+            failed = true;
+        }
+    }
+
+    DynamicDetour detour = DynamicDetour.FromConf(gamedata, "CGameClient::FileReceived");
+    if(detour)
+    {
+        if(!detour.Enable(Hook_Post, OnFileReceived))
+        {
+            LogError("[Gamedata] Failed to enable detour: CGameClient::FileReceived");
+            failed = true;
+        }
+
+        delete detour;
+    }
+    else
+    {
+        LogError("[Gamedata] Could not find CGameClient::FileReceived");
+        failed = true;
+    }
+
+    detour = DynamicDetour.FromConf(gamedata, "CGameClient::FileDenied");
+    if(detour)
+    {
+        if(!detour.Enable(Hook_Post, OnFileDenied))
+        {
+            LogError("[Gamedata] Failed to enable detour: CGameClient::FileDenied");
+            failed = true;
+        }
+
+        delete detour;
+    }
+    else
+    {
+        LogError("[Gamedata] Could not find CGameClient::FileDenied");
+        failed = true;
+    }
+
+    if(failed)
+        ThrowError("Gamedata failed, see error logs");
+
+    SendListing = new ArrayList(sizeof(FileEnum));
+    RequestListing = new ArrayList(sizeof(FileEnum));
+    RegAdminCmd("sm_filenet_send", Command_TestSend, ADMFLAG_ROOT, "Test using send file");
+    RegAdminCmd("sm_filenet_request", Command_TestRequest, ADMFLAG_ROOT, "Test using request file");
 }
 
 public Action Command_TestSend(int client, int args)
 {
-	char buffer[PLATFORM_MAX_PATH];
-	GetCmdArgString(buffer, sizeof(buffer));
-	ReplaceString(buffer, sizeof(buffer), "\"", "");
+    char buffer[PLATFORM_MAX_PATH];
+    GetCmdArgString(buffer, sizeof(buffer));
+    ReplaceString(buffer, sizeof(buffer), "\"", "");
 
-	CNetChan chan = CNetChan(client);
-	if(!chan)
-	{
-		ReplyToCommand(client, "Address invalid");
-	}
-	else if(chan.IsFileInWaitingList(buffer))
-	{
-		ReplyToCommand(client, "File already in waiting list");
-	}
-	else if(chan.SendFile(buffer))
-	{
-		ReplyToCommand(client, "Sent file to client");
-	}
-	else
-	{
-		ReplyToCommand(client, "File failed to send");
-	}
-	return Plugin_Handled;
+    CNetChan chan = CNetChan(client);
+    if(!chan)
+    {
+        ReplyToCommand(client, "Address invalid");
+    }
+    else if(chan.IsFileInWaitingList(buffer))
+    {
+        ReplyToCommand(client, "File already in waiting list");
+    }
+    else if(chan.SendFile(buffer))
+    {
+        ReplyToCommand(client, "Sent file to client");
+    }
+    else
+    {
+        ReplyToCommand(client, "File failed to send");
+    }
+    return Plugin_Handled;
 }
 
 public Action Command_TestRequest(int client, int args)
 {
-	char buffer[PLATFORM_MAX_PATH];
-	GetCmdArgString(buffer, sizeof(buffer));
-	ReplaceString(buffer, sizeof(buffer), "\"", "");
+    char buffer[PLATFORM_MAX_PATH];
+    GetCmdArgString(buffer, sizeof(buffer));
+    ReplaceString(buffer, sizeof(buffer), "\"", "");
 
-	CNetChan chan = CNetChan(client);
-	if(!chan)
-	{
-		ReplyToCommand(client, "Address invalid");
-	}
-	else
-	{
-		chan.RequestFile(buffer);
-		ReplyToCommand(client, "Requested file from client");
-	}
-	return Plugin_Handled;
+    CNetChan chan = CNetChan(client);
+    if(!chan)
+    {
+        ReplyToCommand(client, "Address invalid");
+    }
+    else
+    {
+        chan.RequestFile(buffer);
+        ReplyToCommand(client, "Requested file from client");
+    }
+
+    return Plugin_Handled;
 }
 
 public void OnClientDisconnect_Post(int client)
 {
-	static FileEnum info;
+    static FileEnum info;
 
-	int match = -1;
-	while((match = SendListing.FindValue(client, FileEnum::Client)) != -1)
-	{
-		SendListing.GetArray(match, info);
-		SendListing.Erase(match);
+    int match = -1;
+    while((match = SendListing.FindValue(client, FileEnum::Client)) != -1)
+    {
+        SendListing.GetArray(match, info);
+        SendListing.Erase(match);
 
-		CallSentFileFinish(info, false);
-	}
+        CallSentFileFinish(info, false);
+    }
 
-	match = -1;
-	while((match = RequestListing.FindValue(client, FileEnum::Client)) != -1)
-	{
-		RequestListing.GetArray(match, info);
-		RequestListing.Erase(match);
+    match = -1;
+    while((match = RequestListing.FindValue(client, FileEnum::Client)) != -1)
+    {
+        RequestListing.GetArray(match, info);
+        RequestListing.Erase(match);
 
-		CallRequestFileFinish(info, false);
-	}
+        CallRequestFileFinish(info, false);
+    }
 
-	delete SendingTimer[client];
-	CurrentlySending[client][0] = 0;
+    delete SendingTimer[client];
+    CurrentlySending[client][0] = 0;
 }
 
 public MRESReturn OnFileReceived(Address address, DHookParam param)
 {
-	int id = param.Get(2);
-	CNetChan chan = SDKCall(SDKGetNetChannel, address);
-
-	int length = RequestListing.Length;
-	for(int i; i < length; i++)
-	{
-		static FileEnum info;
-		RequestListing.GetArray(i, info);
-		if(info.Id == id && chan == CNetChan(info.Client))
-		{
-			RequestListing.Erase(i);
-			CallRequestFileFinish(info, true);
-			break;
-		}
-	}
-	return MRES_Ignored;
+    int id = param.Get(2);
+    int length = RequestListing.Length;
+    for(int i; i < length; i++)
+    {
+        static FileEnum info;
+        RequestListing.GetArray(i, info);
+        if(info.Id == id)
+        {
+            RequestListing.Erase(i);
+            CallRequestFileFinish(info, true);
+            break;
+        }
+    }
+    return MRES_Ignored;
 }
 
 public MRESReturn OnFileDenied(Address address, DHookParam param)
 {
-	int id = param.Get(2);
-	CNetChan chan = SDKCall(SDKGetNetChannel, address);
-
-	int length = RequestListing.Length;
-	for(int i; i < length; i++)
-	{
-		static FileEnum info;
-		RequestListing.GetArray(i, info);
-		if(info.Id == id && chan == CNetChan(info.Client))
-		{
-			RequestListing.Erase(i);
-			CallRequestFileFinish(info, false);
-			break;
-		}
-	}
-	return MRES_Ignored;
+    int id = param.Get(2);
+    int length = RequestListing.Length;
+    for(int i; i < length; i++)
+    {
+        static FileEnum info;
+        RequestListing.GetArray(i, info);
+        if(info.Id == id)
+        {
+            RequestListing.Erase(i);
+            CallRequestFileFinish(info, false);
+            break;
+        }
+    }
+    return MRES_Ignored;
 }
 
 public Action Timer_SendingClient(Handle timer, int client)
 {
-	CNetChan chan = CNetChan(client);
-	if(!chan)
-		return Plugin_Continue;
-	
-	if(CurrentlySending[client][0])
-	{
-		// Client still downloading this file
-		if(chan.IsFileInWaitingList(CurrentlySending[client]))
-			return Plugin_Continue;
-		
-		// We finished this file
-		int length = SendListing.Length;
-		for(int i; i < length; i++)
-		{
-			static FileEnum info;
-			SendListing.GetArray(i, info);
-			if(info.Client == client && StrEqual(info.Filename, CurrentlySending[client], false))
-			{
-				SendListing.Erase(i);
-				CallSentFileFinish(info, true);
-				break;
-			}
-		}
+    CNetChan chan = CNetChan(client);
+    if(!chan)
+        return Plugin_Continue;
 
-		CurrentlySending[client][0] = 0;
-	}
+    if(CurrentlySending[client][0])
+    {
+        // Client still downloading this file
+        if(chan.IsFileInWaitingList(CurrentlySending[client]))
+            return Plugin_Continue;
 
-	int length = SendListing.Length;
-	for(int i; i < length; i++)
-	{
-		static FileEnum info;
-		SendListing.GetArray(i, info);
-		if(info.Client == client)
-		{
-			if(chan.SendFile(info.Filename))
-			{
-				strcopy(CurrentlySending[client], sizeof(CurrentlySending[]), info.Filename);
-			}
-			else
-			{
-				// Failed reasons tend to be bad names, bad sizes, etc.
-				SendListing.Erase(i);
-				CallSentFileFinish(info, false);
-			}
+        // We finished this file
+        int length = SendListing.Length;
+        for(int i; i < length; i++)
+        {
+            static FileEnum info;
+            SendListing.GetArray(i, info);
+            if(info.Client == client && StrEqual(info.Filename, CurrentlySending[client], false))
+            {
+                SendListing.Erase(i);
+                CallSentFileFinish(info, true);
+                break;
+            }
+        }
 
-			return Plugin_Continue;
-		}	
-	}
+        CurrentlySending[client][0] = 0;
+    }
 
-	// No more files to send
-	SendingTimer[client] = null;
-	return Plugin_Stop;
+    int length = SendListing.Length;
+    for(int i; i < length; i++)
+    {
+        static FileEnum info;
+        SendListing.GetArray(i, info);
+        if(info.Client == client)
+        {
+            if(chan.SendFile(info.Filename))
+            {
+                strcopy(CurrentlySending[client], sizeof(CurrentlySending[]), info.Filename);
+            }
+            else
+            {
+                // Failed reasons tend to be bad names, bad sizes, etc.
+                SendListing.Erase(i);
+                CallSentFileFinish(info, false);
+            }
+
+            return Plugin_Continue;
+        }
+    }
+
+    // No more files to send
+    SendingTimer[client] = null;
+    return Plugin_Stop;
+}
+
+public void OnClientPutInServer(int client)
+{
+	PrintToServer("Net Channel: %i", SDKGetNetChannel);
 }
 
 static void CallSentFileFinish(const FileEnum info, bool success)
 {
-	if(info.Func && info.Func != INVALID_FUNCTION)
-	{
-		Call_StartFunction(info.Plugin, info.Func);
-		Call_PushCell(info.Client);
-		Call_PushString(info.Filename);
-		Call_PushCell(success);
-		Call_PushCell(info.Data);
-		Call_Finish();
-	}
+    if(info.Func && info.Func != INVALID_FUNCTION)
+    {
+        Call_StartFunction(info.Plugin, info.Func);
+        Call_PushCell(info.Client);
+        Call_PushString(info.Filename);
+        Call_PushCell(success);
+        Call_PushCell(info.Data);
+        Call_Finish();
+    }
 }
 
 static void CallRequestFileFinish(const FileEnum info, bool success)
 {
-	if(info.Func && info.Func != INVALID_FUNCTION)
-	{
-		Call_StartFunction(info.Plugin, info.Func);
-		Call_PushCell(info.Client);
-		Call_PushString(info.Filename);
-		Call_PushCell(info.Id);
-		Call_PushCell(success);
-		Call_PushCell(info.Data);
-		Call_Finish();
-	}
+    if(info.Func && info.Func != INVALID_FUNCTION)
+    {
+        Call_StartFunction(info.Plugin, info.Func);
+        Call_PushCell(info.Client);
+        Call_PushString(info.Filename);
+        Call_PushCell(info.Id);
+        Call_PushCell(success);
+        Call_PushCell(info.Data);
+        Call_Finish();
+    }
 }
 
 void StartNative()
 {
-	if(!SendListing)
-		ThrowNativeError(SP_ERROR_NATIVE, "Please wait until OnAllPluginsLoaded");
+    if(!SendListing)
+        ThrowNativeError(SP_ERROR_NATIVE, "Please wait until OnAllPluginsLoaded");
 }
 
 void StartSendingClient(int client)
 {
-	SendingTimer[client] = CreateTimer(0.5, Timer_SendingClient, client, TIMER_REPEAT);
-	Timer_SendingClient(null, client);
+        SendingTimer[client] = CreateTimer(0.5, Timer_SendingClient, client, TIMER_REPEAT);
+        Timer_SendingClient(null, client);
 }
 
 int GetNativeClient(int param)
 {
-	int client = GetNativeCell(param);
-	if(client < 1 || client > MaxClients)
-		ThrowNativeError(SP_ERROR_NATIVE, "Invalid client index %d", client);
-	
-	if(!IsClientInGame(client))
-		ThrowNativeError(SP_ERROR_NATIVE, "Client %d is not in-game", client);
-	
-	if(IsFakeClient(client))
-		ThrowNativeError(SP_ERROR_NATIVE, "Client %d is a bot player", client);
-	
-	return client;
+    int client = GetNativeCell(param);
+    if(client < 1 || client > MaxClients)
+        ThrowNativeError(SP_ERROR_NATIVE, "Invalid client index %d", client);
+
+    if(!IsClientInGame(client))
+        ThrowNativeError(SP_ERROR_NATIVE, "Client %d is not in-game", client);
+
+    if(IsFakeClient(client))
+        ThrowNativeError(SP_ERROR_NATIVE, "Client %d is a bot player", client);
+
+    return client;
 }
 
 bool FileExistsForClient(int client, const char[] filename)
 {
-	int length = SendListing.Length;
-	for(int i; i < length; i++)
-	{
-		static FileEnum info;
-		SendListing.GetArray(i, info);
-		if(info.Client == client)
-		{
-			if(StrEqual(info.Filename, filename, false))
-				return true;
-		}	
-	}
-	
-	return false;
+    int length = SendListing.Length;
+    for(int i; i < length; i++)
+    {
+        static FileEnum info;
+        SendListing.GetArray(i, info);
+        if(info.Client == client)
+        {
+            if(StrEqual(info.Filename, filename, false))
+                return true;
+        }
+    }
+
+    return false;
 }
 
 public any Native_SendFile(Handle plugin, int params)
 {
-	StartNative();
+    StartNative();
 
-	FileEnum info;
-	info.Client = GetNativeClient(1);
-	GetNativeString(2, info.Filename, sizeof(info.Filename));
+    FileEnum info;
+    info.Client = GetNativeClient(1);
+    GetNativeString(2, info.Filename, sizeof(info.Filename));
 
-	info.Plugin = plugin;
-	info.Func = GetNativeFunction(3);
-	info.Data = GetNativeCell(4);
+    info.Plugin = plugin;
+    info.Func = GetNativeFunction(3);
+    info.Data = GetNativeCell(4);
 
-	SendListing.PushArray(info);
+    SendListing.PushArray(info);
 
-	StartSendingClient(info.Client);
-	return true;
+    StartSendingClient(info.Client);
+    return true;
 }
 
 public any Native_RequestFile(Handle plugin, int params)
 {
-	StartNative();
+    StartNative();
 
-	FileEnum info;
-	info.Client = GetNativeClient(1);
-	GetNativeString(2, info.Filename, sizeof(info.Filename));
+    FileEnum info;
+    info.Client = GetNativeClient(1);
+    GetNativeString(2, info.Filename, sizeof(info.Filename));
 
-	info.Plugin = plugin;
-	info.Func = GetNativeFunction(3);
-	info.Data = GetNativeCell(4);
+    info.Plugin = plugin;
+    info.Func = GetNativeFunction(3);
+    info.Data = GetNativeCell(4);
 
-	CNetChan chan = CNetChan(info.Client);
-	if(!chan)
-		ThrowError("Native_RequestFile: Client address is invalid");
-	
-	info.Id = chan.RequestFile(info.Filename);
-	RequestListing.PushArray(info);
-	return info.Id;
+    CNetChan chan = CNetChan(info.Client);
+    if(!chan)
+        ThrowError("Client address is invalid");
+
+    info.Id = chan.RequestFile(info.Filename);
+    RequestListing.PushArray(info);
+    return info.Id;
 }
 
 public any Native_IsFileInWaitingList(Handle plugin, int params)
 {
-	StartNative();
+    StartNative();
 
-	int client = GetNativeCell(1);
+    int client = GetNativeCell(1);
 
-	if(SendingTimer[client])	// Just to double check with CNetChan::IsFileInWaitingList
-		TriggerTimer(SendingTimer[client], true);
+    if(SendingTimer[client])	// Just to double check with CNetChan::IsFileInWaitingList
+        TriggerTimer(SendingTimer[client], true);
 
-	int length;
-	GetNativeStringLength(2, length);
-	char[] filename = new char[++length];
-	GetNativeString(2, filename, length);
-	
-	return FileExistsForClient(client, filename);
+    int length;
+    GetNativeStringLength(2, length);
+    char[] filename = new char[++length];
+    GetNativeString(2, filename, length);
+
+    return FileExistsForClient(client, filename);
 }
 
 public any Native_GetNetChanPtr(Handle plugin, int params)
@@ -498,7 +508,7 @@ public any Native_GetNetChanPtr(Handle plugin, int params)
 	int client = GetNativeCell(1);
 	
 	CNetChan chan = CNetChan(client);
-	if(!chan)
+	if(!chan || g_EngineVersion == Engine_CSGO)
 		return Address_Null;
 		
 	return chan;

--- a/scripting/filenetwork.sp
+++ b/scripting/filenetwork.sp
@@ -71,7 +71,8 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
     CreateNative("FileNet_SendFile", Native_SendFile);
     CreateNative("FileNet_RequestFile", Native_RequestFile);
     CreateNative("FileNet_IsFileInWaitingList", Native_IsFileInWaitingList);
-
+    CreateNative("FileNet_GetNetChanPtr", Native_GetNetChanPtr);
+	
     RegPluginLibrary("filenetwork");
     return APLRes_Success;
 }

--- a/scripting/filenetwork.sp
+++ b/scripting/filenetwork.sp
@@ -9,12 +9,13 @@
 
 enum struct FileEnum
 {
-	int Client;
-	char Filename[PLATFORM_MAX_PATH];
-	Handle Plugin;
-	Function Func;
-	any Data;
-	int Id;
+    int Client;
+    char Filename[PLATFORM_MAX_PATH];
+    Handle Plugin;
+    Function Func;
+    any Data;
+
+    int Id;
 }
 
 Handle SDKGetPlayerNetInfo;
@@ -35,460 +36,468 @@ ArrayList RequestListing;
 
 methodmap CNetChan
 {
-	public CNetChan(int client)
-	{
-		return SDKCall(SDKGetPlayerNetInfo, EngineAddress, client);
-	}
+    public CNetChan(int client)
+    {
+        return SDKCall(SDKGetPlayerNetInfo, EngineAddress, client);
+    }
 
-	public bool SendFile(const char[] filename)
-	{
-		return SDKCall(SDKSendFile, this, filename, TransferID++);
-	}
-	public int RequestFile(const char[] filename)
-	{
-		return SDKCall(SDKRequestFile, this, filename);
-	}
-	public bool IsFileInWaitingList(const char[] filename)
-	{
-		return SDKCall(SDKIsFileInWaitingList, this, filename);
-	}
+    public bool SendFile(const char[] filename)
+    {
+        return SDKCall(SDKSendFile, this, filename, TransferID++);
+    }
+    public int RequestFile(const char[] filename)
+    {
+        return SDKCall(SDKRequestFile, this, filename);
+    }
+    public bool IsFileInWaitingList(const char[] filename)
+    {
+        return SDKCall(SDKIsFileInWaitingList, this, filename);
+    }
 }
+
+EngineVersion g_EngineVersion;
 
 public Plugin myinfo =
 {
-	name		=	"File Network",
-	author		=	"Batfoxkid",
-	description	=	"But what if, no loading screen",
-	version		=	PLUGIN_VERSION,
-	url			=	"github.com/Batfoxkid/File-Network"
+    name		=	"File Network",
+    author		=	"Batfoxkid & KoNLiG",
+    description	=	"But what if, no loading screen",
+    version		=	PLUGIN_VERSION,
+    url			=	"github.com/Batfoxkid/File-Network"
 }
 
 public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
 {
-	CreateNative("FileNet_SendFile", Native_SendFile);
-	CreateNative("FileNet_RequestFile", Native_RequestFile);
-	CreateNative("FileNet_IsFileInWaitingList", Native_IsFileInWaitingList);
-	CreateNative("FileNet_GetNetChanPtr", Native_GetNetChanPtr);
-	
-	RegPluginLibrary("filenetwork");
-	return APLRes_Success;
+    CreateNative("FileNet_SendFile", Native_SendFile);
+    CreateNative("FileNet_RequestFile", Native_RequestFile);
+    CreateNative("FileNet_IsFileInWaitingList", Native_IsFileInWaitingList);
+
+    RegPluginLibrary("filenetwork");
+    return APLRes_Success;
 }
 
 public void OnPluginStart()
 {
-	GameData gamedata = new GameData("filenetwork");
-	
-	char identifier[64];
-	if(!gamedata.GetKeyValue("EngineInterface", identifier, sizeof(identifier)))
-		SetFailState("[Gamedata] Could not find EngineInterface");
-	
-	StartPrepSDKCall(SDKCall_Static);
-	PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CreateInterface");
-	PrepSDKCall_AddParameter(SDKType_String, SDKPass_Pointer);
-	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Pointer, VDECODE_FLAG_ALLOWNULL);
-	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
-	Handle sdkcall = EndPrepSDKCall();
-	if(!sdkcall)
-		SetFailState("[Gamedata] Could not find CreateInterface");
-	
-	EngineAddress = SDKCall(sdkcall, identifier, 0);
-	if(EngineAddress == Address_Null)
-		SetFailState("[Gamedata] EngineInterface is incorrect for mod");
-	
-	delete sdkcall;
-	
-	bool failed;
+    g_EngineVersion = GetEngineVersion();
 
-	StartPrepSDKCall(SDKCall_Raw);
-	PrepSDKCall_SetFromConf(gamedata, SDKConf_Virtual, "GetPlayerNetInfo");
-	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);
-	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
-	SDKGetPlayerNetInfo = EndPrepSDKCall();
-	if(!SDKGetPlayerNetInfo)
-	{
-		LogError("[Gamedata] Could not find GetPlayerNetInfo");
-		failed = true;
-	}
-	
-	StartPrepSDKCall(SDKCall_Raw);
-	PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CNetChan::SendFile");
-	PrepSDKCall_AddParameter(SDKType_String, SDKPass_Pointer);
-	PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);
-	PrepSDKCall_SetReturnInfo(SDKType_Bool, SDKPass_ByValue);
-	SDKSendFile = EndPrepSDKCall();
-	if(!SDKSendFile)
-	{
-		LogError("[Gamedata] Could not find CNetChan::SendFile");
-		failed = true;
-	}
-	
-	StartPrepSDKCall(SDKCall_Raw);
-	PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CNetChan::RequestFile");
-	PrepSDKCall_AddParameter(SDKType_String, SDKPass_Pointer);
-	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_ByValue);
-	SDKRequestFile = EndPrepSDKCall();
-	if(!SDKRequestFile)
-	{
-		LogError("[Gamedata] Could not find CNetChan::RequestFile");
-		failed = true;
-	}
-	
-	StartPrepSDKCall(SDKCall_Raw);
-	PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CNetChan::IsFileInWaitingList");
-	PrepSDKCall_AddParameter(SDKType_String, SDKPass_Pointer);
-	PrepSDKCall_SetReturnInfo(SDKType_Bool, SDKPass_ByValue);
-	SDKIsFileInWaitingList = EndPrepSDKCall();
-	if(!SDKIsFileInWaitingList)
-	{
-		LogError("[Gamedata] Could not find CNetChan::IsFileInWaitingList");
-		failed = true;
-	}
-	
-	StartPrepSDKCall(SDKCall_Raw);
-	PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CBaseClient::GetNetChannel");
-	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_ByValue);
-	SDKGetNetChannel = EndPrepSDKCall();
-	if(!SDKGetNetChannel)
-	{
-		LogError("[Gamedata] Could not find CBaseClient::GetNetChannel");
-		failed = true;
-	}
+    GameData gamedata = new GameData("filenetwork");
 
-	DynamicDetour detour = DynamicDetour.FromConf(gamedata, "CGameClient::FileReceived");
-	if(detour)
-	{
-		if(!detour.Enable(Hook_Post, OnFileReceived))
-		{
-			LogError("[Gamedata] Failed to enable detour: CGameClient::FileReceived");
-			failed = true;
-		}
-		
-		delete detour;
-	}
-	else
-	{
-		LogError("[Gamedata] Could not find CGameClient::FileReceived");
-		failed = true;
-	}
+    char identifier[64];
+    if(!gamedata.GetKeyValue("EngineInterface", identifier, sizeof(identifier)))
+        SetFailState("[Gamedata] Could not find EngineInterface");
 
-	detour = DynamicDetour.FromConf(gamedata, "CGameClient::FileDenied");
-	if(detour)
-	{
-		if(!detour.Enable(Hook_Post, OnFileDenied))
-		{
-			LogError("[Gamedata] Failed to enable detour: CGameClient::FileDenied");
-			failed = true;
-		}
-		
-		delete detour;
-	}
-	else
-	{
-		LogError("[Gamedata] Could not find CGameClient::FileDenied");
-		failed = true;
-	}
+    StartPrepSDKCall(SDKCall_Static);
+    PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CreateInterface");
+    PrepSDKCall_AddParameter(SDKType_String, SDKPass_Pointer);
+    PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Pointer, VDECODE_FLAG_ALLOWNULL);
+    PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
+    Handle sdkcall = EndPrepSDKCall();
+    if(!sdkcall)
+        SetFailState("[Gamedata] Could not find CreateInterface");
 
-	if(failed)
-		ThrowError("Gamedata failed, see error logs");
-	
-	SendListing = new ArrayList(sizeof(FileEnum));
-	RequestListing = new ArrayList(sizeof(FileEnum));
-	RegAdminCmd("sm_filenet_send", Command_TestSend, ADMFLAG_ROOT, "Test using send file");
-	RegAdminCmd("sm_filenet_request", Command_TestRequest, ADMFLAG_ROOT, "Test using request file");
+    EngineAddress = SDKCall(sdkcall, identifier, 0);
+    if(EngineAddress == Address_Null)
+        SetFailState("[Gamedata] EngineInterface is incorrect for mod");
+
+    delete sdkcall;
+
+    bool failed;
+
+    StartPrepSDKCall(SDKCall_Raw);
+    PrepSDKCall_SetFromConf(gamedata, SDKConf_Virtual, "GetPlayerNetInfo");
+    PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);
+    PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
+    SDKGetPlayerNetInfo = EndPrepSDKCall();
+    if(!SDKGetPlayerNetInfo)
+    {
+        LogError("[Gamedata] Could not find GetPlayerNetInfo");
+        failed = true;
+    }
+
+    StartPrepSDKCall(SDKCall_Raw);
+    PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CNetChan::SendFile");
+    PrepSDKCall_AddParameter(SDKType_String, SDKPass_Pointer);
+    PrepSDKCall_AddParameter(SDKType_PlainOldData, SDKPass_Plain);
+    PrepSDKCall_SetReturnInfo(SDKType_Bool, SDKPass_ByValue);
+    SDKSendFile = EndPrepSDKCall();
+    if(!SDKSendFile)
+    {
+        LogError("[Gamedata] Could not find CNetChan::SendFile");
+        failed = true;
+    }
+
+    StartPrepSDKCall(SDKCall_Raw);
+    PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CNetChan::RequestFile");
+    PrepSDKCall_AddParameter(SDKType_String, SDKPass_Pointer);
+    PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_ByValue);
+    SDKRequestFile = EndPrepSDKCall();
+    if(!SDKRequestFile)
+    {
+        LogError("[Gamedata] Could not find CNetChan::RequestFile");
+        failed = true;
+    }
+
+    StartPrepSDKCall(SDKCall_Raw);
+    PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CNetChan::IsFileInWaitingList");
+    PrepSDKCall_AddParameter(SDKType_String, SDKPass_Pointer);
+    PrepSDKCall_SetReturnInfo(SDKType_Bool, SDKPass_ByValue);
+    SDKIsFileInWaitingList = EndPrepSDKCall();
+    if(!SDKIsFileInWaitingList)
+    {
+        LogError("[Gamedata] Could not find CNetChan::IsFileInWaitingList");
+        failed = true;
+    }
+
+    if (g_EngineVersion != Engine_CSGO)
+    {
+        StartPrepSDKCall(SDKCall_Raw);
+        PrepSDKCall_SetFromConf(gamedata, SDKConf_Signature, "CBaseClient::GetNetChannel");
+        PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_ByValue);
+        SDKGetNetChannel = EndPrepSDKCall();
+        if(!SDKGetNetChannel)
+        {
+            LogError("[Gamedata] Could not find CBaseClient::GetNetChannel");
+            failed = true;
+        }
+    }
+
+    DynamicDetour detour = DynamicDetour.FromConf(gamedata, "CGameClient::FileReceived");
+    if(detour)
+    {
+        if(!detour.Enable(Hook_Post, OnFileReceived))
+        {
+            LogError("[Gamedata] Failed to enable detour: CGameClient::FileReceived");
+            failed = true;
+        }
+
+        delete detour;
+    }
+    else
+    {
+        LogError("[Gamedata] Could not find CGameClient::FileReceived");
+        failed = true;
+    }
+
+    detour = DynamicDetour.FromConf(gamedata, "CGameClient::FileDenied");
+    if(detour)
+    {
+        if(!detour.Enable(Hook_Post, OnFileDenied))
+        {
+            LogError("[Gamedata] Failed to enable detour: CGameClient::FileDenied");
+            failed = true;
+        }
+
+        delete detour;
+    }
+    else
+    {
+        LogError("[Gamedata] Could not find CGameClient::FileDenied");
+        failed = true;
+    }
+
+    if(failed)
+        ThrowError("Gamedata failed, see error logs");
+
+    SendListing = new ArrayList(sizeof(FileEnum));
+    RequestListing = new ArrayList(sizeof(FileEnum));
+    RegAdminCmd("sm_filenet_send", Command_TestSend, ADMFLAG_ROOT, "Test using send file");
+    RegAdminCmd("sm_filenet_request", Command_TestRequest, ADMFLAG_ROOT, "Test using request file");
 }
 
 public Action Command_TestSend(int client, int args)
 {
-	char buffer[PLATFORM_MAX_PATH];
-	GetCmdArgString(buffer, sizeof(buffer));
-	ReplaceString(buffer, sizeof(buffer), "\"", "");
+    char buffer[PLATFORM_MAX_PATH];
+    GetCmdArgString(buffer, sizeof(buffer));
+    ReplaceString(buffer, sizeof(buffer), "\"", "");
 
-	CNetChan chan = CNetChan(client);
-	if(!chan)
-	{
-		ReplyToCommand(client, "Address invalid");
-	}
-	else if(chan.IsFileInWaitingList(buffer))
-	{
-		ReplyToCommand(client, "File already in waiting list");
-	}
-	else if(chan.SendFile(buffer))
-	{
-		ReplyToCommand(client, "Sent file to client");
-	}
-	else
-	{
-		ReplyToCommand(client, "File failed to send");
-	}
-	return Plugin_Handled;
+    CNetChan chan = CNetChan(client);
+    if(!chan)
+    {
+        ReplyToCommand(client, "Address invalid");
+    }
+    else if(chan.IsFileInWaitingList(buffer))
+    {
+        ReplyToCommand(client, "File already in waiting list");
+    }
+    else if(chan.SendFile(buffer))
+    {
+        ReplyToCommand(client, "Sent file to client");
+    }
+    else
+    {
+        ReplyToCommand(client, "File failed to send");
+    }
+    return Plugin_Handled;
 }
 
 public Action Command_TestRequest(int client, int args)
 {
-	char buffer[PLATFORM_MAX_PATH];
-	GetCmdArgString(buffer, sizeof(buffer));
-	ReplaceString(buffer, sizeof(buffer), "\"", "");
+    char buffer[PLATFORM_MAX_PATH];
+    GetCmdArgString(buffer, sizeof(buffer));
+    ReplaceString(buffer, sizeof(buffer), "\"", "");
 
-	CNetChan chan = CNetChan(client);
-	if(!chan)
-	{
-		ReplyToCommand(client, "Address invalid");
-	}
-	else
-	{
-		chan.RequestFile(buffer);
-		ReplyToCommand(client, "Requested file from client");
-	}
-	return Plugin_Handled;
+    CNetChan chan = CNetChan(client);
+    if(!chan)
+    {
+        ReplyToCommand(client, "Address invalid");
+    }
+    else
+    {
+        chan.RequestFile(buffer);
+        ReplyToCommand(client, "Requested file from client");
+    }
+
+    return Plugin_Handled;
 }
 
 public void OnClientDisconnect_Post(int client)
 {
-	static FileEnum info;
+    static FileEnum info;
 
-	int match = -1;
-	while((match = SendListing.FindValue(client, FileEnum::Client)) != -1)
-	{
-		SendListing.GetArray(match, info);
-		SendListing.Erase(match);
+    int match = -1;
+    while((match = SendListing.FindValue(client, FileEnum::Client)) != -1)
+    {
+        SendListing.GetArray(match, info);
+        SendListing.Erase(match);
 
-		CallSentFileFinish(info, false);
-	}
+        CallSentFileFinish(info, false);
+    }
 
-	match = -1;
-	while((match = RequestListing.FindValue(client, FileEnum::Client)) != -1)
-	{
-		RequestListing.GetArray(match, info);
-		RequestListing.Erase(match);
+    match = -1;
+    while((match = RequestListing.FindValue(client, FileEnum::Client)) != -1)
+    {
+        RequestListing.GetArray(match, info);
+        RequestListing.Erase(match);
 
-		CallRequestFileFinish(info, false);
-	}
+        CallRequestFileFinish(info, false);
+    }
 
-	delete SendingTimer[client];
-	CurrentlySending[client][0] = 0;
+    delete SendingTimer[client];
+    CurrentlySending[client][0] = 0;
 }
 
 public MRESReturn OnFileReceived(Address address, DHookParam param)
 {
-	int id = param.Get(2);
-	CNetChan chan = SDKCall(SDKGetNetChannel, address);
-
-	int length = RequestListing.Length;
-	for(int i; i < length; i++)
-	{
-		static FileEnum info;
-		RequestListing.GetArray(i, info);
-		if(info.Id == id && chan == CNetChan(info.Client))
-		{
-			RequestListing.Erase(i);
-			CallRequestFileFinish(info, true);
-			break;
-		}
-	}
-	return MRES_Ignored;
+    int id = param.Get(2);
+    int length = RequestListing.Length;
+    for(int i; i < length; i++)
+    {
+        static FileEnum info;
+        RequestListing.GetArray(i, info);
+        if(info.Id == id)
+        {
+            RequestListing.Erase(i);
+            CallRequestFileFinish(info, true);
+            break;
+        }
+    }
+    return MRES_Ignored;
 }
 
 public MRESReturn OnFileDenied(Address address, DHookParam param)
 {
-	int id = param.Get(2);
-	CNetChan chan = SDKCall(SDKGetNetChannel, address);
-
-	int length = RequestListing.Length;
-	for(int i; i < length; i++)
-	{
-		static FileEnum info;
-		RequestListing.GetArray(i, info);
-		if(info.Id == id && chan == CNetChan(info.Client))
-		{
-			RequestListing.Erase(i);
-			CallRequestFileFinish(info, false);
-			break;
-		}
-	}
-	return MRES_Ignored;
+    int id = param.Get(2);
+    int length = RequestListing.Length;
+    for(int i; i < length; i++)
+    {
+        static FileEnum info;
+        RequestListing.GetArray(i, info);
+        if(info.Id == id)
+        {
+            RequestListing.Erase(i);
+            CallRequestFileFinish(info, false);
+            break;
+        }
+    }
+    return MRES_Ignored;
 }
 
 public Action Timer_SendingClient(Handle timer, int client)
 {
-	CNetChan chan = CNetChan(client);
-	if(!chan)
-		return Plugin_Continue;
-	
-	if(CurrentlySending[client][0])
-	{
-		// Client still downloading this file
-		if(chan.IsFileInWaitingList(CurrentlySending[client]))
-			return Plugin_Continue;
-		
-		// We finished this file
-		int length = SendListing.Length;
-		for(int i; i < length; i++)
-		{
-			static FileEnum info;
-			SendListing.GetArray(i, info);
-			if(info.Client == client && StrEqual(info.Filename, CurrentlySending[client], false))
-			{
-				SendListing.Erase(i);
-				CallSentFileFinish(info, true);
-				break;
-			}
-		}
+    CNetChan chan = CNetChan(client);
+    if(!chan)
+        return Plugin_Continue;
 
-		CurrentlySending[client][0] = 0;
-	}
+    if(CurrentlySending[client][0])
+    {
+        // Client still downloading this file
+        if(chan.IsFileInWaitingList(CurrentlySending[client]))
+            return Plugin_Continue;
 
-	int length = SendListing.Length;
-	for(int i; i < length; i++)
-	{
-		static FileEnum info;
-		SendListing.GetArray(i, info);
-		if(info.Client == client)
-		{
-			if(chan.SendFile(info.Filename))
-			{
-				strcopy(CurrentlySending[client], sizeof(CurrentlySending[]), info.Filename);
-			}
-			else
-			{
-				// Failed reasons tend to be bad names, bad sizes, etc.
-				SendListing.Erase(i);
-				CallSentFileFinish(info, false);
-			}
+        // We finished this file
+        int length = SendListing.Length;
+        for(int i; i < length; i++)
+        {
+            static FileEnum info;
+            SendListing.GetArray(i, info);
+            if(info.Client == client && StrEqual(info.Filename, CurrentlySending[client], false))
+            {
+                SendListing.Erase(i);
+                CallSentFileFinish(info, true);
+                break;
+            }
+        }
 
-			return Plugin_Continue;
-		}	
-	}
+        CurrentlySending[client][0] = 0;
+    }
 
-	// No more files to send
-	SendingTimer[client] = null;
-	return Plugin_Stop;
+    int length = SendListing.Length;
+    for(int i; i < length; i++)
+    {
+        static FileEnum info;
+        SendListing.GetArray(i, info);
+        if(info.Client == client)
+        {
+            if(chan.SendFile(info.Filename))
+            {
+                strcopy(CurrentlySending[client], sizeof(CurrentlySending[]), info.Filename);
+            }
+            else
+            {
+                // Failed reasons tend to be bad names, bad sizes, etc.
+                SendListing.Erase(i);
+                CallSentFileFinish(info, false);
+            }
+
+            return Plugin_Continue;
+        }
+    }
+
+    // No more files to send
+    SendingTimer[client] = null;
+    return Plugin_Stop;
+}
+
+public void OnClientPutInServer(int client)
+{
+	PrintToServer("Net Channel: %i", SDKGetNetChannel);
 }
 
 static void CallSentFileFinish(const FileEnum info, bool success)
 {
-	if(info.Func && info.Func != INVALID_FUNCTION)
-	{
-		Call_StartFunction(info.Plugin, info.Func);
-		Call_PushCell(info.Client);
-		Call_PushString(info.Filename);
-		Call_PushCell(success);
-		Call_PushCell(info.Data);
-		Call_Finish();
-	}
+    if(info.Func && info.Func != INVALID_FUNCTION)
+    {
+        Call_StartFunction(info.Plugin, info.Func);
+        Call_PushCell(info.Client);
+        Call_PushString(info.Filename);
+        Call_PushCell(success);
+        Call_PushCell(info.Data);
+        Call_Finish();
+    }
 }
 
 static void CallRequestFileFinish(const FileEnum info, bool success)
 {
-	if(info.Func && info.Func != INVALID_FUNCTION)
-	{
-		Call_StartFunction(info.Plugin, info.Func);
-		Call_PushCell(info.Client);
-		Call_PushString(info.Filename);
-		Call_PushCell(info.Id);
-		Call_PushCell(success);
-		Call_PushCell(info.Data);
-		Call_Finish();
-	}
+    if(info.Func && info.Func != INVALID_FUNCTION)
+    {
+        Call_StartFunction(info.Plugin, info.Func);
+        Call_PushCell(info.Client);
+        Call_PushString(info.Filename);
+        Call_PushCell(info.Id);
+        Call_PushCell(success);
+        Call_PushCell(info.Data);
+        Call_Finish();
+    }
 }
 
 void StartNative()
 {
-	if(!SendListing)
-		ThrowNativeError(SP_ERROR_NATIVE, "Please wait until OnAllPluginsLoaded");
+    if(!SendListing)
+        ThrowNativeError(SP_ERROR_NATIVE, "Please wait until OnAllPluginsLoaded");
 }
 
 void StartSendingClient(int client)
 {
-	SendingTimer[client] = CreateTimer(0.5, Timer_SendingClient, client, TIMER_REPEAT);
-	Timer_SendingClient(null, client);
+        SendingTimer[client] = CreateTimer(0.5, Timer_SendingClient, client, TIMER_REPEAT);
+        Timer_SendingClient(null, client);
 }
 
 int GetNativeClient(int param)
 {
-	int client = GetNativeCell(param);
-	if(client < 1 || client > MaxClients)
-		ThrowNativeError(SP_ERROR_NATIVE, "Invalid client index %d", client);
-	
-	if(!IsClientInGame(client))
-		ThrowNativeError(SP_ERROR_NATIVE, "Client %d is not in-game", client);
-	
-	if(IsFakeClient(client))
-		ThrowNativeError(SP_ERROR_NATIVE, "Client %d is a bot player", client);
-	
-	return client;
+    int client = GetNativeCell(param);
+    if(client < 1 || client > MaxClients)
+        ThrowNativeError(SP_ERROR_NATIVE, "Invalid client index %d", client);
+
+    if(!IsClientInGame(client))
+        ThrowNativeError(SP_ERROR_NATIVE, "Client %d is not in-game", client);
+
+    if(IsFakeClient(client))
+        ThrowNativeError(SP_ERROR_NATIVE, "Client %d is a bot player", client);
+
+    return client;
 }
 
 bool FileExistsForClient(int client, const char[] filename)
 {
-	int length = SendListing.Length;
-	for(int i; i < length; i++)
-	{
-		static FileEnum info;
-		SendListing.GetArray(i, info);
-		if(info.Client == client)
-		{
-			if(StrEqual(info.Filename, filename, false))
-				return true;
-		}	
-	}
-	
-	return false;
+    int length = SendListing.Length;
+    for(int i; i < length; i++)
+    {
+        static FileEnum info;
+        SendListing.GetArray(i, info);
+        if(info.Client == client)
+        {
+            if(StrEqual(info.Filename, filename, false))
+                return true;
+        }
+    }
+
+    return false;
 }
 
 public any Native_SendFile(Handle plugin, int params)
 {
-	StartNative();
+    StartNative();
 
-	FileEnum info;
-	info.Client = GetNativeClient(1);
-	GetNativeString(2, info.Filename, sizeof(info.Filename));
+    FileEnum info;
+    info.Client = GetNativeClient(1);
+    GetNativeString(2, info.Filename, sizeof(info.Filename));
 
-	info.Plugin = plugin;
-	info.Func = GetNativeFunction(3);
-	info.Data = GetNativeCell(4);
+    info.Plugin = plugin;
+    info.Func = GetNativeFunction(3);
+    info.Data = GetNativeCell(4);
 
-	SendListing.PushArray(info);
+    SendListing.PushArray(info);
 
-	StartSendingClient(info.Client);
-	return true;
+    StartSendingClient(info.Client);
+    return true;
 }
 
 public any Native_RequestFile(Handle plugin, int params)
 {
-	StartNative();
+    StartNative();
 
-	FileEnum info;
-	info.Client = GetNativeClient(1);
-	GetNativeString(2, info.Filename, sizeof(info.Filename));
+    FileEnum info;
+    info.Client = GetNativeClient(1);
+    GetNativeString(2, info.Filename, sizeof(info.Filename));
 
-	info.Plugin = plugin;
-	info.Func = GetNativeFunction(3);
-	info.Data = GetNativeCell(4);
+    info.Plugin = plugin;
+    info.Func = GetNativeFunction(3);
+    info.Data = GetNativeCell(4);
 
-	CNetChan chan = CNetChan(info.Client);
-	if(!chan)
-		ThrowError("Native_RequestFile: Client address is invalid");
-	
-	info.Id = chan.RequestFile(info.Filename);
-	RequestListing.PushArray(info);
-	return info.Id;
+    CNetChan chan = CNetChan(info.Client);
+    if(!chan)
+        ThrowError("Client address is invalid");
+
+    info.Id = chan.RequestFile(info.Filename);
+    RequestListing.PushArray(info);
+    return info.Id;
 }
 
 public any Native_IsFileInWaitingList(Handle plugin, int params)
 {
-	StartNative();
+    StartNative();
 
-	int client = GetNativeCell(1);
+    int client = GetNativeCell(1);
 
-	if(SendingTimer[client])	// Just to double check with CNetChan::IsFileInWaitingList
-		TriggerTimer(SendingTimer[client], true);
+    if(SendingTimer[client])	// Just to double check with CNetChan::IsFileInWaitingList
+        TriggerTimer(SendingTimer[client], true);
 
-	int length;
-	GetNativeStringLength(2, length);
-	char[] filename = new char[++length];
-	GetNativeString(2, filename, length);
-	
-	return FileExistsForClient(client, filename);
+    int length;
+    GetNativeStringLength(2, length);
+    char[] filename = new char[++length];
+    GetNativeString(2, filename, length);
+
+    return FileExistsForClient(client, filename);
 }
 
 public any Native_GetNetChanPtr(Handle plugin, int params)
@@ -498,7 +507,7 @@ public any Native_GetNetChanPtr(Handle plugin, int params)
 	int client = GetNativeCell(1);
 	
 	CNetChan chan = CNetChan(client);
-	if(!chan)
+	if(!chan || g_EngineVersion == Engine_CSGO)
 		return Address_Null;
 		
 	return chan;

--- a/scripting/include/filenetwork.inc
+++ b/scripting/include/filenetwork.inc
@@ -84,7 +84,7 @@ native bool FileNet_IsFileInWaitingList(int client, const char[] file);
  * 
  * @return			True if the file is now queued to be sent, false otherwise
  */
-native bool FileNet_SendFile(int client, const char[] file, FileNet_SendFileResult callback = INVALID_FUNCTION, any data = 0, bool skip = false);
+native bool FileNet_SendFile(int client, const char[] file, FileNet_SendFileResult callback = INVALID_FUNCTION, any data = 0);
 
 /**
  * Requests a file to be sent from the client

--- a/scripting/include/filenetwork.inc
+++ b/scripting/include/filenetwork.inc
@@ -79,12 +79,13 @@ native bool FileNet_IsFileInWaitingList(int client, const char[] file);
  * @param file		Filepath of sent file
  * @param callback	Optional callback when file is done
  * @param data		Optional value to pass to the callback function
+ * @param skip		Skip querying client sv_allowupload value before queuying the file
  * 
  * @error			Invalid client index, client is not in game, or a fake client
  * 
  * @return			True if the file is now queued to be sent, false otherwise
  */
-native bool FileNet_SendFile(int client, const char[] file, FileNet_SendFileResult callback = INVALID_FUNCTION, any data = 0);
+native bool FileNet_SendFile(int client, const char[] file, FileNet_SendFileResult callback = INVALID_FUNCTION, any data = 0, bool skip = false);
 
 /**
  * Requests a file to be sent from the client

--- a/scripting/include/filenetwork.inc
+++ b/scripting/include/filenetwork.inc
@@ -79,7 +79,6 @@ native bool FileNet_IsFileInWaitingList(int client, const char[] file);
  * @param file		Filepath of sent file
  * @param callback	Optional callback when file is done
  * @param data		Optional value to pass to the callback function
- * @param skip		Skip querying client sv_allowupload value before queuying the file
  * 
  * @error			Invalid client index, client is not in game, or a fake client
  * 


### PR DESCRIPTION
Lets plugin authors choose whether they want File Network to query sv_allowupload in FileNet_SendFile or not. Can be rather useful in cases where plugins relying on File Network have their own cvar query implementations, and having a 2nd one would complicate the logic. (For example, my solution needs FileNetwork to queue the file as fast as possible without any timers and additional queries involved, I check cvars before I get to send/request anything).